### PR TITLE
Improves property setter performance by avoiding NSString when possible

### DIFF
--- a/Project/UISS/UISSPropertySetter.m
+++ b/Project/UISS/UISSPropertySetter.m
@@ -71,13 +71,17 @@
     unsigned int count = 0;
     Method *methods = class_copyMethodList(class, &count);
 
-    NSString *selectorPrefix = self.selectorPrefix;
+    const char *selectorPrefix = self.selectorPrefix.UTF8String;
+    size_t selectorPrefixLength = strlen(selectorPrefix);
 
     for (int i = 0; i < count; i++) {
         SEL selector = method_getName(methods[i]);
-        NSString *selectorString = NSStringFromSelector(selector);
 
-        if ([selectorString hasPrefix:selectorPrefix]) { // reducing the use of regular expression for performance reasons
+        BOOL hasPrefix = strncmp(selectorPrefix, sel_getName(selector), selectorPrefixLength) == 0;
+
+        if (hasPrefix) { // reducing the use of NSString & regular expression for performance reasons
+            NSString *selectorString = NSStringFromSelector(selector);
+
             if ([selectorString rangeOfString:regexp options:NSRegularExpressionSearch].location != NSNotFound) {
                 // this favours selector with shorter label
                 // the purpose of this is to pick forState: instead of forStates:


### PR DESCRIPTION
This change reduces the footprint of this method in profiling trace from 500-600 ms to ~80 ms on iPhone 6+/iOS 10.1.